### PR TITLE
Ignore updates to scala-xml, so it stays at 1.3.0 forever

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,4 @@
+# Ignore updates to scala-xml, so it stays at 1.3.0 forever
+updates.ignore = [
+  { groupId = "org.scala-lang.modules", artifactId = "scala-xml" }
+]

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,4 @@
-# Ignore updates to scala-xml, so it stays at 1.3.0 forever
-updates.ignore = [
-  { groupId = "org.scala-lang.modules", artifactId = "scala-xml" }
+# Pin scala-xml at 1.x forever
+updates.pin = [
+  { groupId = "org.scala-lang.modules", artifactId = "scala-xml", version = "1." }
 ]


### PR DESCRIPTION
The purpose of this module is to set the scala-xml version where it is, so we should tell that to `scala-steward`.

See:
- #6