### PR TITLE
Set tlBaseVersion

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.0" // your current series x.y
+ThisBuild / tlBaseVersion := "0.23" // your current series x.y
 
 ThisBuild / licenses := Seq(License.Apache2)
 ThisBuild / developers := List(


### PR DESCRIPTION
sbt-typelevel verifies that the base version is consistent with the tags.  When we tagged the first release, we lost that consistency, so subsequent PRs and merges started to fail.  This should fix it.

This was done as "configure MiMa" PR in a bunch of the other spinoff modules, but unlike most of those, this one has a new ID, so it's not necessary here.