### PR TITLE
Archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # http4s-scala-xml-1
 
-This is a backport of [http4s'][http4s] integration module for
-[scala-xml][scala-xml] based on scala-xml-1.x.  Most users will want
-scala-xml-2.x support, which is in the standard `http4s-scala-xml`
-module.
+This was a backport of [http4s'][http4s] integration module for
+[scala-xml] based on scala-xml-1.x.  Support for both 
+scala-xml-1.x and scala-xml-2.x is now maintained in [http4s-scala-xml].
+This repository is now archived.
 
 ## Why?
 
@@ -13,5 +13,6 @@ with `http4s-twirl` or any other scala-xml-1.x library, we offer this
 backport.
 
 [http4s]: https://http4s.org/
+[http4s-scala-xml]: https://github.com/http4s/http4s-scala-xml
 [scala-xml]: https://github.com/scala/scala-xml
 [twirl]: https://github.com/playframework/twirl


### PR DESCRIPTION
In light of https://github.com/http4s/http4s-scala-xml/pull/29, we can archive this repo and focus there (or on http4s-fs2-data!).